### PR TITLE
added ical command

### DIFF
--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -186,8 +186,15 @@ sub cmd_ical {
         if ($task->duration) {
             my $event = Data::ICal::Entry::Event->new();
 
+            # the summary (what you see when looking at all calendar events)
+            # will be the project name and any tags (in parentheses)
+            my $summary = $task->project;
+            $summary .= ' (' . join(', ',@{$task->tags}) . ')'
+                if $task->has_tags;
+
             $event->add_properties(
-                summary => $task->project,
+                summary => $summary,
+                # if a user opens a calendar event they see the description
                 description => $task->description,
             );
             $event->start($task->start);

--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -689,6 +689,22 @@ Also calc sums per tag.
 
 Lists all found trackfiles and their respective duration before printing out the report.
 
+=head2 ical
+
+    ~/perl/Your-Project$ tracker ical
+
+    Print out an iCalendar calendar of events to standard out.
+
+Example:
+
+    ~/perl/Your-Project$ tracker ical > ~/work.ics
+
+    # ... open ~/work.ics in your least hated calendar/scheduling application
+
+=head3 Options:
+
+The same options as for L<worked>
+
 =head2 init
 
     ~/perl/Your-Project$ tracker init


### PR DESCRIPTION
added an ical command to core that outputs an iCalendar compatible sequence of Events to standard out. this can be redirected to a file and opened in outlook, etc. for manager types ;)

(I am a bit inexperienced with both git and moose; so any feedback w.r.t. incorrect use is appreciated)
