### PR TITLE
fix RT.pm when ticket subject is undef + when ticket has already an owner

### DIFF
--- a/lib/App/TimeTracker/Command/RT.pm
+++ b/lib/App/TimeTracker/Command/RT.pm
@@ -98,7 +98,7 @@ after ['cmd_start','cmd_append'] => sub {
     return unless $ticket;
     try {
         my $do_store=0;
-        if ($self->config->{rt}{set_owner_to} && !$ticket->owner) {
+        if ($self->config->{rt}{set_owner_to} && ($ticket->owner eq 'Nobody')) {
             $ticket->owner($self->config->{rt}{set_owner_to});
             $do_store=1;
         }


### PR DESCRIPTION
- when RT ticket exists but subject is undef fix
- setting RT ticket owner only when not set already (prevents error message)
