### PR TITLE
output the JSON in its canonical form

### DIFF
--- a/lib/App/TimeTracker/Data/Task.pm
+++ b/lib/App/TimeTracker/Data/Task.pm
@@ -13,7 +13,7 @@ use User::pwent;
 
 use MooseX::Storage;
 with Storage(
-    format => [ JSONpm => { json_opts => { pretty => 1 } } ],
+    format => [ JSONpm => { json_opts => { pretty => 1, canonical => 1 } } ],
     io     => "File",
 );
 


### PR DESCRIPTION
Not a huge thing, but ensures that the keys of the
JSON object are always in the same order. It minimizes
the noise if, for example, you have the ~/.TimeTracker
directory under revision control.