### PR TITLE
Fixes link in POD documentation.

### DIFF
--- a/lib/App/TimeTracker.pm
+++ b/lib/App/TimeTracker.pm
@@ -299,7 +299,7 @@ __END__
 
 =head1 SYNOPSIS
 
-Backend for the C<tracker> command. See L<tracker> and/or C<perldoc tracker> for details.
+Backend for the C<tracker> command. See L<tracker|https://metacpan.org/pod/release/DOMM/App-TimeTracker-3.000/bin/tracker> and/or C<perldoc tracker> for details.
 
 =head1 CONTRIBUTORS
 

--- a/lib/App/TimeTracker.pm
+++ b/lib/App/TimeTracker.pm
@@ -299,7 +299,7 @@ __END__
 
 =head1 SYNOPSIS
 
-Backend for the C<tracker> command. See L<tracker|https://metacpan.org/pod/release/DOMM/App-TimeTracker-3.000/bin/tracker> and/or C<perldoc tracker> for details.
+Backend for the C<tracker> command. See L<tracker|https://metacpan.org/pod/distribution/App-TimeTracker/bin/tracker> and/or C<perldoc tracker> for details.
 
 =head1 CONTRIBUTORS
 


### PR DESCRIPTION
Hello, this is from https://pullrequest.club.

This fixes a link to the `tracker` script in the POD documentation for `App::TimeTracker`. For some reason the `L<tracker>` POD command in `App::TimeTracker` was translated into
https://metacpan.org/pod/distribution/App-TimeTracker/bin/tracker_bash_autocomplete when it should be https://metacpan.org/pod/release/DOMM/App-TimeTracker-3.000/bin/tracker.