### PR TITLE
Fix pod link version 2.

### DIFF
--- a/bin/tracker_bash_autocomplete
+++ b/bin/tracker_bash_autocomplete
@@ -1,5 +1,5 @@
 # ABSTRACT: tracker bash autocomplete
-# PODNAME: tracker bash autocomplete
+# PODNAME: tracker_bash_autocomplete
 
 _tracker() 
 {

--- a/lib/App/TimeTracker.pm
+++ b/lib/App/TimeTracker.pm
@@ -299,7 +299,7 @@ __END__
 
 =head1 SYNOPSIS
 
-Backend for the C<tracker> command. See L<tracker|https://metacpan.org/pod/distribution/App-TimeTracker/bin/tracker> and/or C<perldoc tracker> for details.
+Backend for the C<tracker> command. See L<tracker> and/or C<perldoc tracker> for details.
 
 =head1 CONTRIBUTORS
 


### PR DESCRIPTION
After some [discussion](https://stackoverflow.com/q/58660214/2173773) at stackoverflow.com,  another way to fix the pod link issue was suggested by user @Grinnz. This PR thus reverts the change introduced in commit 20cc7c22fa639f760925611bf51cd3d5e2d666f2 and instead introduces the fix in the file `bin/tracker_bash_autocomplete`.  I am not sure if this will work but I thought I should mention it since it seems like a more correct approach. You probably have to do a release and see if it works, if not you can always revert to the other fix?
