### PR TITLE
Some tracker docs fixes

### DIFF
--- a/bin/tracker
+++ b/bin/tracker
@@ -38,7 +38,7 @@ about each plugin in C<App::TimeTracker::Command::PLUGIN-NAME>.
 
 Up to version 2.028 a lot of plugins where included in the main distribution
 C<App-TimeTracker>. To make installation easier and faster, all non-core
-command plugins have been moved into distinct, standalone distribution.
+command plugins have been moved into distinct, standalone distributions.
 
 The following plugins are affected:
 

--- a/bin/tracker
+++ b/bin/tracker
@@ -36,7 +36,9 @@ about each plugin in C<App::TimeTracker::Command::PLUGIN-NAME>.
 
 =head2 Note about (missing) Plugins
 
-Up to version 2.028 a lot of plugins where included in the main distribution C<App-TimeTracker>. To make installation easier and faster, all non-core command plugins have been moved into distinct, standalone distribution.
+Up to version 2.028 a lot of plugins where included in the main distribution
+C<App-TimeTracker>. To make installation easier and faster, all non-core
+command plugins have been moved into distinct, standalone distribution.
 
 The following plugins are affected:
 

--- a/bin/tracker
+++ b/bin/tracker
@@ -25,7 +25,7 @@ __END__
 
 C<tracker> is the front end script to L<App::TimeTracker>. C<tracker>
 allows you to easily track and report the time you spend on various
-jobs, projects, tasks etc from the command line.
+jobs, projects, tasks etc. from the command line.
 
 Custom commands or adaptations to your workflow can be implemented via
 an "interesting" set of L<Moose>-powered plugins. You can configure

--- a/bin/tracker
+++ b/bin/tracker
@@ -89,15 +89,35 @@ CPAN.pm is available on ancient Perls, and feels a bit ancient, too.
 
   cpan App::TimeTracker
 
-=head2 From a tarball or git checkout
+=head2 From a tarball
 
-To install L<App::TimeTracker> from a tarball or a git checkout, do the usual
-CPAN module install dance:
+To install L<App::TimeTracker> from a tarball, do the usual CPAN module
+install dance:
 
   ~/perl/App-TimeTracker$ perl Build.PL
   ~/perl/App-TimeTracker$ ./Build
   ~/perl/App-TimeTracker$ ./Build test
   ~/perl/App-TimeTracker$ ./Build install  # might require sudo
+
+=head2 From a git checkout
+
+Clone the repository if you have not already done so, and enter the
+C<App-TimeTracker> directory:
+
+  ~$ git clone git@github.com:domm/App-TimeTracker.git
+  ~$ cd App-TimeTracker
+
+C<App-TimeTracker> uses L<Dist::Zilla> to build, test and install the code,
+hence this must be installed first, e.g. with C<cpanm>:
+
+  ~/path/to/App-Tracker$ cpanm Dist::Zilla
+
+Now install the distribution's dependencies, test and install in the usual
+manner for C<Dist::Zilla> projects:
+
+  ~/path/to/App-Tracker$ dzil listdeps --missing | cpanm
+  ~/path/to/App-Tracker$ dzil test
+  ~/path/to/App-Tracker$ dzil install
 
 =head1 SETUP
 


### PR DESCRIPTION
While reading the docs for the `tracker` program, I noticed a few things that needed correcting.  Mostly these were typos or simply wrapping long lines, however the build and install documentation for a git checkout were no longer correct (it mentioned using `Build.PL` which is only available in the tarball of the distribution).  I've updated this documentation to match how the project is currently built and installed.  I've split these changes into separate commits so that you can cherry pick them as you please.

If you would like anything changed or updated here, please let me know and I'll be happy to update the PR and resubmit :-)