### PR TITLE
Indent incorrectly outdented variable

### DIFF
--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -207,7 +207,7 @@ sub cmd_list {
             : ()
         ),
     );
-my $total=0;
+    my $total=0;
     foreach my $file (@files) {
         my $task = App::TimeTracker::Data::Task->load( $file->stringify );
         my $time = $task->seconds // $task->_build_seconds;


### PR DESCRIPTION
Now the indentation matches the surrounding scope, making it easier to
read the code.