### PR TITLE
Stop gathering vim `.swp` files when building dist

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ copyright_year   = 2011 - 2019
 
 [GatherDir]
 include_dotfiles = 1
+exclude_match = .*\.swp
 [PruneCruft]
 [ManifestSkip]
 [MetaYAML]


### PR DESCRIPTION
Dist::Zilla was trying to include vim `.swp` files when building the
dist prior to testing it (e.g. when running `dzil test`) and this was
causing errors such as:

```
Could not decode UTF-8 t/Command/.core.t.swp; filename set by GatherDir
(Dist::Zilla::Plugin::GatherDir line 225); encoded_content added by
GatherDir (Dist::Zilla::Plugin::GatherDir line 226); error was: UTF-8
"\xA8" does not map to Unicode at
/home/cochrane/perl5/perlbrew/perls/perl-5.20.3/lib/site_perl/5.20.3/x86_64-linux/Encode.pm
line 228.
```

By excluding such files from being gathered, one can keep files open in
vim and still run the test suite in another terminal.