### PR TITLE
Sort list of available commands for consistency

### DIFF
--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -455,6 +455,8 @@ sub cmd_commands {
         push( @commands, $method );
     }
 
+    @commands = sort @commands;
+
     if (   $self->can('autocomplete')
         && $self->autocomplete )
     {

--- a/t/Command/core.t
+++ b/t/Command/core.t
@@ -134,4 +134,32 @@ my $c2 = $p->load_config($tmp->subdir(qw(other_project)));
     like($trap->stdout,qr/$version/,'version: output');
 }
 
+{ # commands
+    @ARGV = ('commands');
+    my $class = $p->setup_class({});
+
+    my $t = $class->name->new(home=>$home, config=>{});
+    trap {$t->cmd_commands};
+    my @core_commands = qw<
+       append
+       commands
+       continue
+       current
+       init
+       list
+       plugins
+       recalc_trackfile
+       report
+       show_config
+       start
+       stop
+       version
+       worked>;
+    my $output = $trap->stdout;
+    my @lines = split /\n/, $output;
+    @lines = grep !/Available commands/, @lines;
+    s/^\s+//g foreach @lines;  # remove leading whitespace from strings
+    is_deeply(\@lines, \@core_commands, 'default list of core commands is sorted');
+}
+
 done_testing();


### PR DESCRIPTION
Subsequent calls of `tracker commands` would provide a different order
of the list of commands each time it was called.  This I found to be
confusing and it was difficult to find the command one was looking for.
Alphabetically sorting the list of available commands makes finding a
given command much easier.  I've also added a test for the `commands`
command to ensure the output is as expected.