### PR TITLE
Purge trailing whitespace in source files

### DIFF
--- a/Changes
+++ b/Changes
@@ -200,7 +200,7 @@ Revision history for App::TimeTracker
 2.008  2011-08-09T15:30:53+0200
     - this is going to be the first release to CPAN since 0.21
     - relaxed decoding of json config files
-    - started to add docs 
+    - started to add docs
     - back to per-dir config files, much saner
     - new commands: show_config, init
     - Better datetime parsing
@@ -251,7 +251,7 @@ Revision history for App::TimeTracker
 
 
 0.20    2009-02-12
-    - switched to new storage system (filesystem base, not sqlite, to 
+    - switched to new storage system (filesystem base, not sqlite, to
       make syncing via git et.al. easier
 
 

--- a/bin/tracker_bash_autocomplete
+++ b/bin/tracker_bash_autocomplete
@@ -1,16 +1,16 @@
 # ABSTRACT: tracker bash autocomplete
 # PODNAME: tracker_bash_autocomplete
 
-_tracker() 
+_tracker()
 {
     local cur prev opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    
+
     #  The basic options we'll complete.
     opts=`tracker commands --autocomplete`
-    
+
 #    #  Complete the arguments to some of the basic commands.
 #    case "${prev}" in
 #        rt)
@@ -24,8 +24,8 @@ _tracker()
 #                return 0
 #                ;;
 #    esac
-    
-   COMPREPLY=($(compgen -W "${opts}" -- ${cur}))  
+
+   COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
    return 0
 }
 complete -F _tracker tracker

--- a/t/Command/core.t
+++ b/t/Command/core.t
@@ -20,7 +20,7 @@ $now->set_time_zone('local');
 my $basetf = $now->ymd('').'-';
 my $tracker_dir = $home->subdir($now->year,sprintf("%02d",$now->month));
 
-{ # init 
+{ # init
     @ARGV=('init');
     my $class = $p->setup_class({});
 

--- a/t/Task/start.t
+++ b/t/Task/start.t
@@ -17,14 +17,14 @@ my $tmp = testlib::Fixtures::setup_tempdir;
         project => 'test',
         start   => DateTime->new(year=>2010,month=>2,day=>26,hour=>10,minute=>5,second=>42),
     });
-    
+
     $capture->start();
     $task->do_start($tmp);
     $capture->stop();
 
     ok(-e $task->storage_location($tmp),'task is saved');
     ok(-e $tmp.'/current','current is set');
-    
+
     my $read = $capture->read;
     like($read,qr/started working on test at 10:05:42/i,'stdout');
 }

--- a/t/Task/storage_location.t
+++ b/t/Task/storage_location.t
@@ -15,8 +15,8 @@ my $tmp = testlib::Fixtures::setup_tempdir;
         project => 'test',
         start   => DateTime->new(year=>2010,month=>2,day=>26,hour=>10,minute=>5,second=>42),
     });
-    
-    cmp_bag ([$task->_filepath],[qw(2010 02 20100226-100542_test.trc)],'filepath has correct elements'); 
+
+    cmp_bag ([$task->_filepath],[qw(2010 02 20100226-100542_test.trc)],'filepath has correct elements');
     is($task->storage_location($tmp),$tmp->file('2010','02','20100226-100542_test.trc'),'storage_location');
 
 }

--- a/t/TimeTracker/find_task_files.t
+++ b/t/TimeTracker/find_task_files.t
@@ -27,7 +27,7 @@ my $t = App::TimeTracker->new(home=>$tmp,config=>{});
         projects=>['TimeTracker'],
     });
     is(scalar @files,7,'got 7 files');
-    is((scalar grep { /App_TimeTracker/ } @files),7,'all match project'); 
+    is((scalar grep { /App_TimeTracker/ } @files),7,'all match project');
 }
 
 {

--- a/t/TimeTracker/helpers.t
+++ b/t/TimeTracker/helpers.t
@@ -54,7 +54,7 @@ my %BASE = ( home=>$tmp, config=>{} );
     );
     my $class_name = $class->name;
     $class_name->_load_attribs_worked($class);
-    
+
     no warnings 'redefine';
     local *DateTime::now = sub { return DateTime->new( year => 2011, month => 9, day => 7, hour => 12 ) };
     {
@@ -62,7 +62,7 @@ my %BASE = ( home=>$tmp, config=>{} );
             %BASE,
             this    => 'week',
         });
-        
+
         is($t1->from->iso8601,'2011-09-05T00:00:00','From 1 ok');
         is($t1->to->iso8601,'2011-09-11T23:59:59','To 1 ok');
     }
@@ -72,27 +72,27 @@ my %BASE = ( home=>$tmp, config=>{} );
             %BASE,
             last    => 'week',
         });
-        
+
         is($t2->from->iso8601,'2011-08-29T00:00:00','From 2 ok');
         is($t2->to->iso8601,'2011-09-04T23:59:59','To 2 ok');
     }
-    
+
     {
         my $t3 = $class_name->new({
             %BASE,
             last    => 'month',
         });
-        
+
         is($t3->from->iso8601,'2011-08-01T00:00:00','From 3 ok');
         is($t3->to->iso8601,'2011-08-31T23:59:59','To 3 ok');
     }
-    
+
     {
         my $t4 = $class_name->new({
             %BASE,
             last    => 'day',
         });
-        
+
         is($t4->from->iso8601,'2011-09-06T00:00:00','From 4 ok');
         is($t4->to->iso8601,'2011-09-06T23:59:59','To 4 ok');
     }

--- a/t/testlib/Fixtures.pm
+++ b/t/testlib/Fixtures.pm
@@ -30,14 +30,14 @@ sub setup_running {
 
     my $tracker_file = $tmp->file('running.trc');
     copy('t/testdata/running.trc',$tracker_file) || die $!;
-    
+
     foreach my $type (qw(current previous)) {
         my $file = $tmp->file($type);
         my $fh = $file->openw;
         say $fh $tracker_file;
         close $fh;
     }
-    
+
     return $tmp;
 }
 


### PR DESCRIPTION
Some projects consider this a must, and will disallow commits to be submitted which contain trailing whitespace (the Linux kernel is an example project where trailing whitespace isn't permitted).  Other projects see whitespace cleanup as simply nit-picking.  Either way I thought I'd submit this fix just in case it's of interest to you :-)