### PR TITLE
Fix off-by-one rounding error in Task->rounded_minutes

### DIFF
--- a/lib/App/TimeTracker/Data/Task.pm
+++ b/lib/App/TimeTracker/Data/Task.pm
@@ -178,10 +178,7 @@ sub do_start {
 
 sub rounded_minutes {
     my $self = shift;
-    my $sec  = $self->seconds;
-    my $rest = 60 - $sec % 60;
-    my $min  = ( $sec + $rest ) / 60;
-    return $min;
+    return sprintf "%.0f", $self->seconds/60;
 }
 
 sub get_detail {

--- a/t/Command/core.t
+++ b/t/Command/core.t
@@ -72,6 +72,9 @@ my $c1 = $p->load_config($tmp->subdir(qw(some_project)));
     my $task = App::TimeTracker::Data::Task->load($tracker_dir->file($basetf.'140000_some_project.trc')->stringify);
     is($task->seconds,15 * 60,'task seconds');
     is($task->duration,'00:15:00','task duration');
+
+    trap {$t->cmd_current};
+    like($trap->stdout, qr/Worked 15 minutes from 14:00:00 till 14:15:00/, '');
 }
 
 { # append

--- a/t/Task/helpers.t
+++ b/t/Task/helpers.t
@@ -29,4 +29,32 @@ use App::TimeTracker::Data::Task;
     is ($task->description_short,'Some Test Task described in a very long sentence...','description_short');
 }
 
+{ # rounded_minutes
+    my $task = App::TimeTracker::Data::Task->new(
+        {
+            project => 'test',
+            start   => DateTime->new(
+                year   => 2010,
+                month  => 2,
+                day    => 26,
+                hour   => 10,
+                minute => 5,
+                second => 0
+            ),
+            description => 'Worked exactly 15 minutes',
+        }
+    );
+    my $stop = DateTime->new(
+        year   => 2010,
+        month  => 2,
+        day    => 26,
+        hour   => 10,
+        minute => 20,
+        second => 0
+    );
+    $task->_calc_duration($stop);
+    is( $task->duration,        '00:15:00', 'task duration is 15 minutes' );
+    is( $task->rounded_minutes, 15,         'rounded_minutes' );
+}
+
 done_testing();


### PR DESCRIPTION
The implementation always added an extra minute to the output, hence
when a task duration showed 00:15:00, the `rounded_minutes` value came
out at 16.  In the general case a duration of 00:x:00 would have a
`rounded_minutes` value of `x+1`.  The solution implemented here uses
a [hint from PerlMonks](https://www.perlmonks.org/bare/?node_id=257208),
which mentioned that to round to the nearest integer one must use
`sprintf "%.0f" $value` instead of `sprintf "%d" $value` because the
latter has the same truncation behaviour as `int()`.  This commit also
adds tests at the `Data::Task` level but also at the `Command::core`
level (which is where I noticed the discrepancy to start with).