### PR TITLE
Bump version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ App::TimeTracker - time tracking for impatient and lazy command line lovers
 
 # VERSION
 
-version 3.003
+version 3.004
 
 # SYNOPSIS
 


### PR DESCRIPTION
After merging to the latest head and running `dzil`, the README got
automatically updated in the working directory to reflect the current
version number.  This patch merges the version update so that it is
reflected in the repository and avoids having unnecessarily unmerged
files in the working directory.