### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: perl
+
+perl:
+    - "5.30"
+    - "5.28"
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+
+install:
+    - dzil authordeps --missing | cpanm --no-skip-satisfied --notest || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied --notest || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - dzil test


### PR DESCRIPTION
This is an initial Travis-CI configuration which works on the current default Travis-CI infrastructure.  Unfortunately, Perl versions 5.10, 5.12 and 5.32 aren't supported by default.  One option to work around this issue would be to use the [Perl Travis Helpers](https://github.com/travis-perl/helpers), although I'm unsure if that's still the current way to do things, hence I've stuck to the default setup here.  If you'd like anything updated or changed with this PR, please let me know and I'll fix things and resubmit as necessary.