### PR TITLE
Remove conflicting Repository Dist::Zilla plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -21,9 +21,9 @@ location = build
 [CopyFilesFromBuild]
 copy = README.md
 [ExecDir]
-[Repository]
 [GitHub::Meta]
 hompage=false
+bugs=0
 [MetaResources]
 homepage=http://timetracker.plix.at
 [CheckChangeLog]


### PR DESCRIPTION
Both the `Repository` and the `GitHub::Meta` plugins set the
`resources.repository.web` distribution metadata attribute.  This causes
the following error when running e.g. `dzil test` or `dzil build`:

```
Duplication of element resources.repository.web at /path/to/Dist/Zilla.pm line 594.
```

and hence the dist can't be built or tested.  This change gets things to
work again.

What really confuses me about this issue is that it only turned up today
and I've not seen it before and the current configuration has been
present for years and the conflicting modules were last released in
2018, so I honestly don't know how this arose so suddenly.  Looking at
the bugs for the `Repository` plugin, it seems that it doesn't play with
other plugins (such as `MetaResources`) nicely, so it seems like the
appropriate plugin to remove from the configuration to solve this issue.

Note that the `bugs` option to `GitHub::Meta` is set to a false value
(this can't be `false` or `no` as this option fails a type constraint in
`GitHub::Meta`) so that the metadata doesn't incorrectly contain a
bugtracker link to GitHub, because the current public policy for this
dist is to use RT for bugs.  (Note that I compared the currently released `META.*` files with those generated from `dzil build` in order to ensure that no extra information appeared in the metadata.)