### PR TITLE
Refer to GitHub bugtracker in documentation

### DIFF
--- a/bin/tracker
+++ b/bin/tracker
@@ -396,7 +396,7 @@ CPAN, offering slightly different features:
 
 =back
 
-=head1 Viewing and reporting Bugs
+=head1 Viewing and reporting bugs
 
 To view and report bugs please use the L<GitHub issues page for
 App::TimeTracker|https://github.com/domm/App-TimeTracker/issues>.

--- a/bin/tracker
+++ b/bin/tracker
@@ -379,8 +379,8 @@ a bug, please feel free to L<fork|http://help.github.com/fork-a-repo/> the
 repo and send us L<pull requests|http://help.github.com/send-pull-requests/>
 to merge your changes.
 
-To report a bug, please B<do not> use the C<< issues >> feature from github;
-use RT instead.
+To report a bug, please use the L<GitHub issues page for
+App::TimeTracker|https://github.com/domm/App-TimeTracker/issues>.
 
 =head2 CPAN
 
@@ -398,10 +398,5 @@ CPAN, offering slightly different features:
 
 =head1 Viewing and reporting Bugs
 
-We use L<rt.cpan.org|http://rt.cpan.org> (thank you
-L<BestPractical|http://rt.bestpractical.com>) for bug reporting. Please do
-not use the C<issues> feature of github! We pay no attention to those...
-
-Please use this URL to view and report bugs:
-
-L<https://rt.cpan.org/Public/Dist/Display.html?Name=App-TimeTracker>
+To view and report bugs please use the L<GitHub issues page for
+App::TimeTracker|https://github.com/domm/App-TimeTracker/issues>.

--- a/dist.ini
+++ b/dist.ini
@@ -23,7 +23,6 @@ copy = README.md
 [ExecDir]
 [Repository]
 [GitHub::Meta]
-hompage=false
 [MetaResources]
 homepage=http://timetracker.plix.at
 [CheckChangeLog]


### PR DESCRIPTION
This patch updates the documentation to point users to GitHub issues for bug reports as opposed to RT, which was used before. The `dist.ini` configuration was already pointing to GitHub; the docs needed updating to reflect this.

I also fixed a minor configuration issue also related to handling metadata sourced from GitHub.