### PR TITLE
Remove search.cpan.org links

### DIFF
--- a/bin/tracker
+++ b/bin/tracker
@@ -79,7 +79,7 @@ available:
   1 distribution installed
 
 If you don't have C<cpanminus> installed yet, L<install it right
-now|http://search.cpan.org/dist/App-cpanminus/lib/App/cpanminus.pm#INSTALLATION>:
+now|https://metacpan.org/pod/distribution/App-cpanminus/lib/App/cpanminus.pm#INSTALLATION>:
 
   ~$ curl -L http://cpanmin.us | perl - --sudo App::cpanminus
 
@@ -385,16 +385,9 @@ use RT instead.
 =head2 CPAN
 
 L<App::TimeTracker> is distributed via L<CPAN|http://cpan.org/>, the
-Comprehensive Perl Archive Network. Here are a few different views of
-CPAN, offering slightly different features:
-
-=over
-
-=item * L<https://metacpan.org/release/App-TimeTracker/>
-
-=item * L<http://search.cpan.org/dist/App-TimeTracker/>
-
-=back
+Comprehensive Perl Archive Network. To view information about
+L<App::TimeTracker> online, visit the L<metacpan page for
+App::TimeTracker|https://metacpan.org/release/App-TimeTracker/>.
 
 =head1 Viewing and reporting Bugs
 

--- a/bin/tracker
+++ b/bin/tracker
@@ -72,10 +72,10 @@ available:
 
   ~$ cpanm App::TimeTracker
   --> Working on App::TimeTracker
-  Fetching http://search.cpan.org/CPAN/authors/id/D/DO/DOMM/App-TimeTracker-2.009.tar.gz ... OK
-  Configuring App-TimeTracker-2.009 ... OK
-  Building and testing App-TimeTracker-2.009 ... OK
-  Successfully installed App-TimeTracker-2.009
+  Fetching http://www.cpan.org/authors/id/D/DO/DOMM/App-TimeTracker-3.004.tar.gz ... OK
+  Configuring App-TimeTracker-3.004 ... OK
+  Building and testing App-TimeTracker-3.004 ... OK
+  Successfully installed App-TimeTracker-3.004
   1 distribution installed
 
 If you don't have C<cpanminus> installed yet, L<install it right


### PR DESCRIPTION
Since search.cpan.org has been completely replaced by metacpan, the docs don't need to refer to search.cpan.org anymore and all references can point to metacpan instead.