### PR TITLE
Extend start command help text when project is missing

### DIFF
--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -18,7 +18,8 @@ sub cmd_start {
 
     unless ( $self->has_current_project ) {
         error_message(
-            "Could not find project\nUse --project or chdir into the project directory"
+            "Could not find project; did you forget to run `tracker init`?\n" .
+            "If not, use --project or chdir into the project directory."
         );
         exit;
     }

--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -8,6 +8,7 @@ use 5.010;
 use Moose::Role;
 use Moose::Util::TypeConstraints;
 use App::TimeTracker::Utils qw(now pretty_date error_message);
+use App::TimeTracker::Constants qw(MISSING_PROJECT_HELP_MSG);
 use File::Copy qw(move);
 use File::Find::Rule;
 use Data::Dumper;
@@ -17,10 +18,7 @@ sub cmd_start {
     my $self = shift;
 
     unless ( $self->has_current_project ) {
-        error_message(
-            "Could not find project; did you forget to run `tracker init`?\n" .
-            "If not, use --project or chdir into the project directory."
-        );
+        error_message( MISSING_PROJECT_HELP_MSG );
         exit;
     }
     $self->cmd_stop('no_exit');

--- a/lib/App/TimeTracker/Constants.pm
+++ b/lib/App/TimeTracker/Constants.pm
@@ -1,0 +1,24 @@
+package App::TimeTracker::Constants;
+use strict;
+use warnings;
+use 5.010;
+
+# ABSTRACT: App::TimeTracker pre-defined constants
+
+use Exporter;
+use parent qw(Exporter);
+
+our @EXPORT      = qw();
+our @EXPORT_OK   = qw(MISSING_PROJECT_HELP_MSG);
+
+use constant MISSING_PROJECT_HELP_MSG =>
+    "Could not find project; did you forget to run `tracker init`?\n" .
+    "If not, use --project or chdir into the project directory.";
+
+1;
+
+__END__
+
+=head1 DESCRIPTION
+
+Pre-defined constants used without the module's internals.

--- a/lib/App/TimeTracker/Proto.pm
+++ b/lib/App/TimeTracker/Proto.pm
@@ -17,6 +17,7 @@ use Carp;
 use Try::Tiny;
 
 use App::TimeTracker::Data::Task;
+use App::TimeTracker::Constants qw(MISSING_PROJECT_HELP_MSG);
 
 has 'home' => (
     is         => 'ro',
@@ -139,10 +140,7 @@ sub setup_class {
             $load_attribs_for_command = '_load_attribs_' . $cmd;
 
             if ($cmd eq 'start' && !$self->has_project) {
-                error_message(
-                    "Could not find project; did you forget to run `tracker init`?\n" .
-                    "If not, use --project or chdir into the project directory."
-                );
+                error_message( MISSING_PROJECT_HELP_MSG );
                 exit;
             }
 

--- a/lib/App/TimeTracker/Proto.pm
+++ b/lib/App/TimeTracker/Proto.pm
@@ -140,7 +140,8 @@ sub setup_class {
 
             if ($cmd eq 'start' && !$self->has_project) {
                 error_message(
-                    "Could not find project\nUse --project or chdir into the project directory"
+                    "Could not find project; did you forget to run `tracker init`?\n" .
+                    "If not, use --project or chdir into the project directory."
                 );
                 exit;
             }

--- a/lib/App/TimeTracker/Utils.pm
+++ b/lib/App/TimeTracker/Utils.pm
@@ -16,7 +16,7 @@ our @EXPORT_OK   = qw(pretty_date now error_message);
 our %EXPORT_TAGS = ( all => \@EXPORT_OK );
 
 sub error_message {
-    return _message( 'bold red', @_ );
+    _message( 'bold red', @_ );
 }
 
 sub _message {

--- a/lib/App/TimeTracker/Utils.pm
+++ b/lib/App/TimeTracker/Utils.pm
@@ -12,15 +12,11 @@ use Exporter;
 use parent qw(Exporter);
 
 our @EXPORT      = qw();
-our @EXPORT_OK   = qw(pretty_date now error_message warning_message);
+our @EXPORT_OK   = qw(pretty_date now error_message);
 our %EXPORT_TAGS = ( all => \@EXPORT_OK );
 
 sub error_message {
     return _message( 'bold red', @_ );
-}
-
-sub warning_message {
-    return _message( 'bold yellow', @_ );
 }
 
 sub _message {

--- a/t/Command/rt_88867_start_help.t
+++ b/t/Command/rt_88867_start_help.t
@@ -28,8 +28,8 @@ my $config = {};
     );
     trap { $t->cmd_start };
     my $expected_start_help_output = <<'EOF';
-Could not find project
-Use --project or chdir into the project directory
+Could not find project; did you forget to run `tracker init`?
+If not, use --project or chdir into the project directory.
 EOF
     is( colorstrip( $trap->stdout ),
         $expected_start_help_output,

--- a/t/Command/rt_88867_start_help.t
+++ b/t/Command/rt_88867_start_help.t
@@ -1,0 +1,39 @@
+use 5.010;
+use strict;
+use warnings;
+use lib qw(t);
+
+use Test::Most;
+use Test::Trap;
+use Test::File;
+use testlib::FakeHomeDir;
+use Term::ANSIColor qw(colorstrip);
+use App::TimeTracker::Proto;
+
+my $tmp  = testlib::Fixtures::setup_tempdir;
+my $home = $tmp->subdir('.TimeTracker');
+$home->mkpath;
+
+my $proto = App::TimeTracker::Proto->new( home => $home, project => '' );
+$proto->load_config($home);
+my $config = {};
+
+# start
+{
+    @ARGV = ('start');
+    my $class = $proto->setup_class($config);
+    my $t     = $class->name->new(
+        home   => $home,
+        config => $config,
+    );
+    trap { $t->cmd_start };
+    my $expected_start_help_output = <<'EOF';
+Could not find project
+Use --project or chdir into the project directory
+EOF
+    is( colorstrip( $trap->stdout ),
+        $expected_start_help_output,
+        'Start command help output with undefined project' );
+}
+
+done_testing();


### PR DESCRIPTION
When the project is missing or unknown at the time the user runs `tracker start`, often the issue is that the user hasn't yet run `tracker init`.  This patch extends the help text in this case to mention a missing `init` in case the user forgot to do this step; it also adds tests for the help text.  This patch should address the first part of the issue mentioned in [RT 88687](https://rt.cpan.org/Public/Bug/Display.html?id=88687).

The most controversial thing I've done in this PR is to remove the `warning_message` utility function, since it's not used anywhere, so I thought it probably can be deleted.  If not, just let me know and I'll update the PR as appropriate.