### PR TITLE
Extend init command documentation

### DIFF
--- a/bin/tracker
+++ b/bin/tracker
@@ -15,6 +15,9 @@ __END__
 
 =head1 SYNOPSIS
 
+  # initialize tracker for the 'Some-Project' directory
+  ~/perl/Some-Project$ tracker init
+
   ~/perl/Some-Project$ tracker start
   Started working on Some-Project at 09:03:41
 

--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -840,7 +840,10 @@ The same options as for L<report|/report>
 
     ~/perl/Your-Project$ tracker init
 
-Create a rather empty F<.tracker.json> config file in the current directory.
+Initialize current directory as a project in which to track time.  This step
+is required before one can use time tracking commands such as
+L<start|/start> and L<stop|/stop>.  The initialization step creates a rather
+empty F<.tracker.json> config file in the current directory.
 
 =head3 No options
 


### PR DESCRIPTION
Extend and clarify the meaning and importance of the `init` command to hopefully reduce new user confusion in the future.