### PR TITLE
Fix Dist::Zilla build problems

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,9 @@
 name    = App-TimeTracker
+license = Perl_5
+copyright_holder = Thomas Klausner
 copyright_year   = 2011 - 2021
 
 [@Author::DOMM]
+[OurPkgVersion]
 homepage = http://timetracker.plix.at/
 Git::GatherDir.include_dotfiles = 1


### PR DESCRIPTION
In order to run `dzil authordeps --missing | cpanm` to completion, it
was necessary to add `OurPkgVersion` to the list of required plugins.
Afterwards, `dzil test` and `dzil listdeps` failed to run due to missing
`license` and `copyright_holder` fields.  These fields have been added
and it is possible to build and test the dist again.

Also, for some reason which I've not yet been able to work out, the version is set to 3.003 automatically in the README. This is definitely incorrect, but I've not been able to find out what's causing that issue.  @domm do you know what could be causing that?

Also, I don't know if this patch is the right way to go about fixing the build issues; it could be that you need to include `OurPkgVersion` into your bundle so that that line is no longer required.  How one gets around the issues with the `license` and `copyright_holder` fields from a bundle, I don't know...