### PR TITLE
Tidy test code via perltidy

### DIFF
--- a/perltidyrc
+++ b/perltidyrc
@@ -1,0 +1,26 @@
+# perltidy settings for this project
+--maximum-line-length=100
+--standard-output
+--standard-error-output
+--nooutdent-long-lines
+--stack-opening-tokens
+--nospace-for-semicolon
+--opening-brace-always-on-right
+--opening-token-right
+--noopening-sub-brace-on-new-line
+--vertical-tightness=2
+--continuation-indentation=4   # ugly with closing parens, but nice with code
+
+# this results in  } } } ); on one line, which I think is ugly
+#--stack-closing-tokens
+
+# defaults, but here for docu:
+--indent-columns=4
+--paren-tightness=1
+--brace-tightness=1
+--square-bracket-tightness=1
+--block-brace-tightness=1
+--closing-token-indentation=0
+
+#--comma-arrow-breakpoints=0
+#--line-up-parentheses

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,8 +1,8 @@
 #!/usr/bin/perl
 use Test::More;
 use lib 'lib';
-use Module::Pluggable search_path => [ 'App::TimeTracker' ];
+use Module::Pluggable search_path => ['App::TimeTracker'];
 
-require_ok( $_ ) for sort __PACKAGE__->plugins;
+require_ok($_) for sort __PACKAGE__->plugins;
 
 done_testing();

--- a/t/Command/core.t
+++ b/t/Command/core.t
@@ -10,175 +10,209 @@ use testlib::FakeHomeDir;
 use App::TimeTracker::Proto;
 local $ENV{TZ} = 'UTC';
 
-my $tmp = testlib::Fixtures::setup_tempdir;
+my $tmp  = testlib::Fixtures::setup_tempdir;
 my $home = $tmp->subdir('.TimeTracker');
 $tmp->subdir('some_project')->mkpath;
 $tmp->subdir('other_project')->mkpath;
-my $p = App::TimeTracker::Proto->new(home=>$home);
+my $p   = App::TimeTracker::Proto->new( home => $home );
 my $now = DateTime->now;
 $now->set_time_zone('local');
-my $basetf = $now->ymd('').'-';
-my $tracker_dir = $home->subdir($now->year,sprintf("%02d",$now->month));
+my $basetf      = $now->ymd('') . '-';
+my $tracker_dir = $home->subdir( $now->year, sprintf( "%02d", $now->month ) );
 
-{ # init
-    @ARGV=('init');
-    my $class = $p->setup_class({});
+{    # init
+    @ARGV = ('init');
+    my $class = $p->setup_class( {} );
 
-    file_exists_ok($home->file('projects.json'));
-    file_exists_ok($home->file('tracker.json'));
-    file_not_exists_ok($tmp->file('some_project','.tracker.json'));
-    file_not_exists_ok($tmp->file('other_project','.tracker.json'));
+    file_exists_ok( $home->file('projects.json') );
+    file_exists_ok( $home->file('tracker.json') );
+    file_not_exists_ok( $tmp->file( 'some_project',  '.tracker.json' ) );
+    file_not_exists_ok( $tmp->file( 'other_project', '.tracker.json' ) );
 
     $p->_build_home($home);
 
-    my $t = $class->name->new(home=>$home, config=>{}, _current_project=>'some_project');
-    trap { $t->cmd_init($tmp->subdir('some_project')) };
-    is($trap->stdout,"Set up this directory for time-tracking via file .tracker.json\n",'init: output');
+    my $t = $class->name->new( home => $home, config => {}, _current_project => 'some_project' );
+    trap { $t->cmd_init( $tmp->subdir('some_project') ) };
+    is( $trap->stdout, "Set up this directory for time-tracking via file .tracker.json\n",
+        'init: output' );
 
-    file_exists_ok($home->file('projects.json'));
-    file_exists_ok($home->file('tracker.json'));
-    file_exists_ok($tmp->file('some_project','.tracker.json'));
+    file_exists_ok( $home->file('projects.json') );
+    file_exists_ok( $home->file('tracker.json') );
+    file_exists_ok( $tmp->file( 'some_project', '.tracker.json' ) );
 
 }
 
-my $c1 = $p->load_config($tmp->subdir(qw(some_project)));
+my $c1 = $p->load_config( $tmp->subdir(qw(some_project)) );
 
-{ # start
-    @ARGV=('start');
+{    # start
+    @ARGV = ('start');
     my $class = $p->setup_class($c1);
 
-    file_not_exists_ok($tracker_dir->file($basetf.'140000_some_project.trc'),'tracker file does not exist yet');
-    my $t = $class->name->new(home=>$home, config=>$c1, _current_project=>'some_project',at=>'14:00');
-    trap {$t->cmd_start };
-    is($trap->stdout,"Started working on some_project at 14:00:00\n",'start: output');
-    file_not_empty_ok($tracker_dir->file($basetf.'140000_some_project.trc'),'tracker file exists');
+    file_not_exists_ok( $tracker_dir->file( $basetf . '140000_some_project.trc' ),
+        'tracker file does not exist yet' );
+    my $t = $class->name->new(
+        home             => $home,
+        config           => $c1,
+        _current_project => 'some_project',
+        at               => '14:00'
+    );
+    trap { $t->cmd_start };
+    is( $trap->stdout, "Started working on some_project at 14:00:00\n", 'start: output' );
+    file_not_empty_ok( $tracker_dir->file( $basetf . '140000_some_project.trc' ),
+        'tracker file exists' );
 }
 
-{ # current
-#    # TODO: need to monkey-patch $class->now to return a mocked value
-    @ARGV=('current');
+{    # current
+
+    #    # TODO: need to monkey-patch $class->now to return a mocked value
+    @ARGV = ('current');
     my $class = $p->setup_class($c1);
-    my $t = $class->name->new(home=>$home, config=>$c1, _current_project=>'some_project');
-    trap {$t->cmd_current };
-    like($trap->stdout, qr/^Working \d{2}:\d{2}:\d{2} on some_project/, 'current project is some_project');
-    like($trap->stdout, qr/Started at 14:00:00/, 'project start time is correct');
+    my $t = $class->name->new( home => $home, config => $c1, _current_project => 'some_project' );
+    trap { $t->cmd_current };
+    like(
+        $trap->stdout,
+        qr/^Working \d{2}:\d{2}:\d{2} on some_project/,
+        'current project is some_project'
+    );
+    like( $trap->stdout, qr/Started at 14:00:00/, 'project start time is correct' );
 }
 
-{ # stop
-    @ARGV=('stop');
+{    # stop
+    @ARGV = ('stop');
     my $class = $p->setup_class($c1);
-    my $t = $class->name->new(home=>$home, config=>$c1, _current_project=>'some_project',at=>'14:15');
-    trap {$t->cmd_stop };
-    is($trap->stdout,"Worked 00:15:00 on some_project\n",'stop: output');
+    my $t     = $class->name->new(
+        home             => $home,
+        config           => $c1,
+        _current_project => 'some_project',
+        at               => '14:15'
+    );
+    trap { $t->cmd_stop };
+    is( $trap->stdout, "Worked 00:15:00 on some_project\n", 'stop: output' );
 
-    my $task = App::TimeTracker::Data::Task->load($tracker_dir->file($basetf.'140000_some_project.trc')->stringify);
-    is($task->seconds,15 * 60,'task seconds');
-    is($task->duration,'00:15:00','task duration');
+    my $task = App::TimeTracker::Data::Task->load(
+        $tracker_dir->file( $basetf . '140000_some_project.trc' )->stringify );
+    is( $task->seconds,  15 * 60,    'task seconds' );
+    is( $task->duration, '00:15:00', 'task duration' );
 
-    trap {$t->cmd_current};
-    like($trap->stdout, qr/Worked 15 minutes from 14:00:00 till 14:15:00/, '');
+    trap { $t->cmd_current };
+    like( $trap->stdout, qr/Worked 15 minutes from 14:00:00 till 14:15:00/, '' );
 }
 
-{ # append
-    @ARGV=('append');
+{    # append
+    @ARGV = ('append');
     my $class = $p->setup_class($c1);
-    my $t = $class->name->new(home=>$home, config=>$c1, _current_project=>'some_project');
-    trap {$t->cmd_append };
-    is($trap->stdout,"Started working on some_project at 14:15:00\n",'stop: output');
+    my $t = $class->name->new( home => $home, config => $c1, _current_project => 'some_project' );
+    trap { $t->cmd_append };
+    is( $trap->stdout, "Started working on some_project at 14:15:00\n", 'stop: output' );
 
-    my $trc = $tracker_dir->file($basetf.'141500_some_project.trc');
-    file_not_empty_ok($trc,'tracker file exists');
-    my $task = App::TimeTracker::Data::Task->load($trc->stringify);
-    is($task->stop,undef,'task stop not set');
+    my $trc = $tracker_dir->file( $basetf . '141500_some_project.trc' );
+    file_not_empty_ok( $trc, 'tracker file exists' );
+    my $task = App::TimeTracker::Data::Task->load( $trc->stringify );
+    is( $task->stop, undef, 'task stop not set' );
 }
 
-{ # init other project
-    file_not_exists_ok($tmp->file('other_project','.tracker.json'));
+{    # init other project
+    file_not_exists_ok( $tmp->file( 'other_project', '.tracker.json' ) );
 
-    @ARGV=('init');
-    my $class = $p->setup_class({});
+    @ARGV = ('init');
+    my $class = $p->setup_class( {} );
 
-    my $t = $class->name->new(home=>$home, config=>{}, _current_project=>'other_project');
-    trap { $t->cmd_init($tmp->subdir('other_project')) };
-    is($trap->stdout,"Set up this directory for time-tracking via file .tracker.json\n",'init: output');
-    file_exists_ok($tmp->file('other_project','.tracker.json'));
+    my $t = $class->name->new( home => $home, config => {}, _current_project => 'other_project' );
+    trap { $t->cmd_init( $tmp->subdir('other_project') ) };
+    is( $trap->stdout, "Set up this directory for time-tracking via file .tracker.json\n",
+        'init: output' );
+    file_exists_ok( $tmp->file( 'other_project', '.tracker.json' ) );
 }
 
-my $c2 = $p->load_config($tmp->subdir(qw(other_project)));
+my $c2 = $p->load_config( $tmp->subdir(qw(other_project)) );
 
-{ # start other project
-    @ARGV=('start');
+{    # start other project
+    @ARGV = ('start');
     my $class = $p->setup_class($c2);
-    my $trc = $tracker_dir->file($basetf.'143000_other_project.trc');
-    file_not_exists_ok($trc,'tracker file does not exist yet');
+    my $trc   = $tracker_dir->file( $basetf . '143000_other_project.trc' );
+    file_not_exists_ok( $trc, 'tracker file does not exist yet' );
 
-    my $t = $class->name->new(home=>$home, config=>$c2, _current_project=>'other_project',at=>'14:30');
-    trap {$t->cmd_start };
-    is($trap->stdout,"Worked 00:15:00 on some_project\nStarted working on other_project at 14:30:00\n",'start: output');
-    file_not_empty_ok($trc,'tracker file exists');
+    my $t = $class->name->new(
+        home             => $home,
+        config           => $c2,
+        _current_project => 'other_project',
+        at               => '14:30'
+    );
+    trap { $t->cmd_start };
+    is( $trap->stdout,
+        "Worked 00:15:00 on some_project\nStarted working on other_project at 14:30:00\n",
+        'start: output'
+    );
+    file_not_empty_ok( $trc, 'tracker file exists' );
 
-    my $task = App::TimeTracker::Data::Task->load($tracker_dir->file($basetf.'141500_some_project.trc')->stringify);
-    is($task->seconds,15 * 60,'prev task seconds');
-    is($task->duration,'00:15:00','prev task duration');
+    my $task = App::TimeTracker::Data::Task->load(
+        $tracker_dir->file( $basetf . '141500_some_project.trc' )->stringify );
+    is( $task->seconds,  15 * 60,    'prev task seconds' );
+    is( $task->duration, '00:15:00', 'prev task duration' );
 }
 
-{ # stop it
-    @ARGV=('stop');
+{    # stop it
+    @ARGV = ('stop');
     my $class = $p->setup_class($c1);
-    my $t = $class->name->new(home=>$home, config=>$c2, _current_project=>'other_project',at=>'14:45');
-    trap {$t->cmd_stop };
-    like($trap->stdout,qr/00:15:00.*other_project/,'stop: output');
+    my $t     = $class->name->new(
+        home             => $home,
+        config           => $c2,
+        _current_project => 'other_project',
+        at               => '14:45'
+    );
+    trap { $t->cmd_stop };
+    like( $trap->stdout, qr/00:15:00.*other_project/, 'stop: output' );
 }
 
-{ # version
-    @ARGV=('version');
+{    # version
+    @ARGV = ('version');
     my $version = App::TimeTracker->VERSION;
-    my $class = $p->setup_class($c1);
-    my $t = $class->name->new(home=>$home, config=>$c2);
-    trap {$t->cmd_version };
-    like($trap->stdout,qr/$version/,'version: output');
+    my $class   = $p->setup_class($c1);
+    my $t       = $class->name->new( home => $home, config => $c2 );
+    trap { $t->cmd_version };
+    like( $trap->stdout, qr/$version/, 'version: output' );
 }
 
-{ # commands
+{    # commands
     @ARGV = ('commands');
-    my $class = $p->setup_class({});
+    my $class = $p->setup_class( {} );
 
-    my $t = $class->name->new(home=>$home, config=>{});
-    trap {$t->cmd_commands};
+    my $t = $class->name->new( home => $home, config => {} );
+    trap { $t->cmd_commands };
     my @core_commands = qw<
-       append
-       commands
-       continue
-       current
-       init
-       list
-       plugins
-       recalc_trackfile
-       report
-       show_config
-       start
-       stop
-       version
-       worked>;
+        append
+        commands
+        continue
+        current
+        init
+        list
+        plugins
+        recalc_trackfile
+        report
+        show_config
+        start
+        stop
+        version
+        worked>;
     my $output = $trap->stdout;
-    my @lines = split /\n/, $output;
+    my @lines  = split /\n/, $output;
     @lines = grep !/Available commands/, @lines;
-    s/^\s+//g foreach @lines;  # remove leading whitespace from strings
-    is_deeply(\@lines, \@core_commands, 'default list of core commands is sorted');
+    s/^\s+//g foreach @lines;    # remove leading whitespace from strings
+    is_deeply( \@lines, \@core_commands, 'default list of core commands is sorted' );
 }
 
-{ # report global
+{    # report global
     @ARGV = ('report');
     my $class = $p->setup_class( $c1, 'report' );
-    my $t = $class->name->new( home => $home, config => $c1, this=>'day' );
+    my $t     = $class->name->new( home => $home, config => $c1, this => 'day' );
     trap { $t->cmd_report };
-    like ($trap->stdout, qr/total\s+00:45:00/, 'report global');
+    like( $trap->stdout, qr/total\s+00:45:00/, 'report global' );
 };
 
-{ # report filter project
+{    # report filter project
     @ARGV = ('report');
     my $class = $p->setup_class( $c1, 'report' );
-    my $t = $class->name->new(
+    my $t     = $class->name->new(
         home      => $home,
         config    => $c1,
         this      => 'day',
@@ -186,7 +220,7 @@ my $c2 = $p->load_config($tmp->subdir(qw(other_project)));
 
     );
     trap { $t->cmd_report };
-    like ($trap->stdout, qr/total\s+00:30:00/, 'report filter project');
+    like( $trap->stdout, qr/total\s+00:30:00/, 'report filter project' );
 }
 
 done_testing();

--- a/t/Command/rt_73859_daychange.t
+++ b/t/Command/rt_73859_daychange.t
@@ -3,8 +3,8 @@ use strict;
 use warnings;
 use lib qw(t);
 
-use Test::MockTime qw(); # this needs to be loaded before DateTime
-                         # http://www.nntp.perl.org/group/perl.datetime/2008/08/msg7043.html
+use Test::MockTime qw();    # this needs to be loaded before DateTime
+                            # http://www.nntp.perl.org/group/perl.datetime/2008/08/msg7043.html
 use Test::Most;
 use Test::Trap;
 use Test::File;
@@ -13,98 +13,150 @@ use App::TimeTracker::Proto;
 use DateTime;
 local $ENV{TZ} = 'UTC';
 
-my $tmp = testlib::Fixtures::setup_tempdir;
-my $home = $tmp->subdir('.TimeTracker');
+my $tmp    = testlib::Fixtures::setup_tempdir;
+my $home   = $tmp->subdir('.TimeTracker');
 my $prjdir = $tmp->subdir('rt73859');
 $home->mkpath;
 $prjdir->mkpath;
-$home->file('projects.json')->spew(iomode => '>:encoding(UTF-8)','{"rt73859":"'.$prjdir.'"}'."\n");
-$prjdir->file('.tracker.json')->spew(iomode => '>:encoding(UTF-8)','{}'."\n");
+$home->file('projects.json')
+    ->spew( iomode => '>:encoding(UTF-8)', '{"rt73859":"' . $prjdir . '"}' . "\n" );
+$prjdir->file('.tracker.json')->spew( iomode => '>:encoding(UTF-8)', '{}' . "\n" );
 
-my $p = App::TimeTracker::Proto->new(home=>$home, project=>'rt73859');
-$p->load_config($home,'rt73859');
-my $tracker_dir = $home->subdir('2012','01');
-my $c = { project=>'rt73859'};
+my $p = App::TimeTracker::Proto->new( home => $home, project => 'rt73859' );
+$p->load_config( $home, 'rt73859' );
+my $tracker_dir = $home->subdir( '2012', '01' );
+my $c           = { project => 'rt73859' };
 
 # test what was reported, but it works
 diag("Test initial bug report");
 
-{ # start
-    my $test_date = DateTime->new(year=>2012,month=>1,day=>9,hour=>21,time_zone=>'local');
-    Test::MockTime::set_fixed_time($test_date->epoch);
+{    # start
+    my $test_date =
+        DateTime->new( year => 2012, month => 1, day => 9, hour => 21, time_zone => 'local' );
+    Test::MockTime::set_fixed_time( $test_date->epoch );
 
-    @ARGV=('start');
+    @ARGV = ('start');
     my $class = $p->setup_class($c);
-    my $t = $class->name->new(home=>$home, config=>$c, _current_project=>'rt73859',at=>'23:30');
-    trap {$t->cmd_start };
-    is($trap->stdout,"Started working on rt73859 at 23:30:00\n",'start: output');
-    file_not_empty_ok($tracker_dir->file('20120109-233000_rt73859.trc'),'tracker file exists');
+    my $t     = $class->name->new(
+        home             => $home,
+        config           => $c,
+        _current_project => 'rt73859',
+        at               => '23:30'
+    );
+    trap { $t->cmd_start };
+    is( $trap->stdout, "Started working on rt73859 at 23:30:00\n", 'start: output' );
+    file_not_empty_ok( $tracker_dir->file('20120109-233000_rt73859.trc'), 'tracker file exists' );
 }
 
-{ # stop
-    my $test_date = DateTime->new(year=>2012,month=>1,day=>10,hour=>'00',minute=>3,time_zone=>'local');
-    Test::MockTime::set_fixed_time($test_date->epoch);
+{    # stop
+    my $test_date = DateTime->new(
+        year      => 2012,
+        month     => 1,
+        day       => 10,
+        hour      => '00',
+        minute    => 3,
+        time_zone => 'local'
+    );
+    Test::MockTime::set_fixed_time( $test_date->epoch );
 
-    @ARGV=('stop');
+    @ARGV = ('stop');
     my $class = $p->setup_class($c);
-    my $t = $class->name->new(home=>$home, config=>$c, _current_project=>'rt73859',at=>'0:30');
-    trap {$t->cmd_stop };
+    my $t     = $class->name->new(
+        home             => $home,
+        config           => $c,
+        _current_project => 'rt73859',
+        at               => '0:30'
+    );
+    trap { $t->cmd_stop };
 
-    is($trap->stdout,"Worked 01:00:00 on rt73859\n",'stop: output');
-    my $task = App::TimeTracker::Data::Task->load($tracker_dir->file('20120109-233000_rt73859.trc')->stringify);
-    is($task->seconds,60 * 60,'task: seconds');
-    is($task->duration,'01:00:00','task: duration');
+    is( $trap->stdout, "Worked 01:00:00 on rt73859\n", 'stop: output' );
+    my $task = App::TimeTracker::Data::Task->load(
+        $tracker_dir->file('20120109-233000_rt73859.trc')->stringify );
+    is( $task->seconds,  60 * 60,    'task: seconds' );
+    is( $task->duration, '01:00:00', 'task: duration' );
 }
-
 
 # ah, I assume there is a different bug:
 # if you issue 'tracker stop --at 00:10' but it is 23:59, the stop-time will be set for the current day, i.e. way before the start time
 # solution do not allow to set stop times that are before the start time.
 diag("Test de facto bug");
 
-{ # start
-    my $test_date = DateTime->new(year=>2012,month=>1,day=>8,hour=>23,minute=>30,time_zone=>'local');
-    Test::MockTime::set_fixed_time($test_date->epoch);
+{    # start
+    my $test_date = DateTime->new(
+        year      => 2012,
+        month     => 1,
+        day       => 8,
+        hour      => 23,
+        minute    => 30,
+        time_zone => 'local'
+    );
+    Test::MockTime::set_fixed_time( $test_date->epoch );
 
-    @ARGV=('start');
+    @ARGV = ('start');
     my $class = $p->setup_class($c);
-    my $t = $class->name->new(home=>$home, config=>$c, _current_project=>'rt73859');
-    trap {$t->cmd_start };
+    my $t     = $class->name->new( home => $home, config => $c, _current_project => 'rt73859' );
+    trap { $t->cmd_start };
 
-    is($trap->stdout,"Started working on rt73859 at 23:30:00\n",'start: output');
-    file_not_empty_ok($tracker_dir->file('20120108-233000_rt73859.trc'),'tracker file exists');
+    is( $trap->stdout, "Started working on rt73859 at 23:30:00\n", 'start: output' );
+    file_not_empty_ok( $tracker_dir->file('20120108-233000_rt73859.trc'), 'tracker file exists' );
 }
 
-{ # stop
-    my $test_date = DateTime->new(year=>2012,month=>1,day=>8,hour=>23,minute=>45,time_zone=>'local');
-    Test::MockTime::set_fixed_time($test_date->epoch);
+{    # stop
+    my $test_date = DateTime->new(
+        year      => 2012,
+        month     => 1,
+        day       => 8,
+        hour      => 23,
+        minute    => 45,
+        time_zone => 'local'
+    );
+    Test::MockTime::set_fixed_time( $test_date->epoch );
 
-    @ARGV=('stop');
+    @ARGV = ('stop');
     my $class = $p->setup_class($c);
-    my $t = $class->name->new(home=>$home, config=>$c, _current_project=>'rt73859',at=>'0:30');
-    trap {$t->cmd_stop };
+    my $t     = $class->name->new(
+        home             => $home,
+        config           => $c,
+        _current_project => 'rt73859',
+        at               => '0:30'
+    );
+    trap { $t->cmd_stop };
 
-    like($trap->stdout,qr/This makes no sense/,'stop: aborted output');
-    my $task = App::TimeTracker::Data::Task->load($tracker_dir->file('20120108-233000_rt73859.trc')->stringify);
-    is($task->stop,undef,'task: no stop time');
-    file_not_empty_ok($home->file('current'),'"current" file still exists');
+    like( $trap->stdout, qr/This makes no sense/, 'stop: aborted output' );
+    my $task = App::TimeTracker::Data::Task->load(
+        $tracker_dir->file('20120108-233000_rt73859.trc')->stringify );
+    is( $task->stop, undef, 'task: no stop time' );
+    file_not_empty_ok( $home->file('current'), '"current" file still exists' );
 }
 
-{ # stop again, with long --at
-    my $test_date = DateTime->new(year=>2012,month=>1,day=>8,hour=>23,minute=>45,time_zone=>'local');
-    Test::MockTime::set_fixed_time($test_date->epoch);
+{    # stop again, with long --at
+    my $test_date = DateTime->new(
+        year      => 2012,
+        month     => 1,
+        day       => 8,
+        hour      => 23,
+        minute    => 45,
+        time_zone => 'local'
+    );
+    Test::MockTime::set_fixed_time( $test_date->epoch );
 
-    @ARGV=('stop');
+    @ARGV = ('stop');
     my $class = $p->setup_class($c);
-    my $t = $class->name->new(home=>$home, config=>$c, _current_project=>'rt73859',at=>'2012-01-09 00:30');
-    trap {$t->cmd_stop };
+    my $t     = $class->name->new(
+        home             => $home,
+        config           => $c,
+        _current_project => 'rt73859',
+        at               => '2012-01-09 00:30'
+    );
+    trap { $t->cmd_stop };
 
-    is($trap->stdout,"Worked 01:00:00 on rt73859\n",'stop: output');
+    is( $trap->stdout, "Worked 01:00:00 on rt73859\n", 'stop: output' );
 
-    my $task = App::TimeTracker::Data::Task->load($tracker_dir->file('20120108-233000_rt73859.trc')->stringify);
-    is($task->seconds,60 * 60,'task seconds');
-    is($task->duration,'01:00:00','task duration');
-    file_not_exists_ok($home->file('current'),'"current" file is gone now');
+    my $task = App::TimeTracker::Data::Task->load(
+        $tracker_dir->file('20120108-233000_rt73859.trc')->stringify );
+    is( $task->seconds,  60 * 60,    'task seconds' );
+    is( $task->duration, '01:00:00', 'task duration' );
+    file_not_exists_ok( $home->file('current'), '"current" file is gone now' );
 }
 
 done_testing();

--- a/t/Command/rt_88867_start_help.t
+++ b/t/Command/rt_88867_start_help.t
@@ -32,8 +32,7 @@ Could not find project; did you forget to run `tracker init`?
 If not, use --project or chdir into the project directory.
 EOF
     is( colorstrip( $trap->stdout ),
-        $expected_start_help_output,
-        'Start command help output with undefined project' );
+        $expected_start_help_output, 'Start command help output with undefined project' );
 }
 
 done_testing();

--- a/t/Proto/config.t
+++ b/t/Proto/config.t
@@ -11,43 +11,43 @@ use Path::Class;
 {
     explain('Test1');
     my $testdir = testlib::Fixtures::setup_tree('tree1');
-    my $p = App::TimeTracker::Proto->new(home=>$testdir);
-    my $c = $p->load_config(dir($testdir,(qw(a b c d))));
-    is($p->project,'d','project d');
-    is($c->{rt}{update_time_worked},1,'deep config');
-    is(keys %{$p->config_file_locations},5, '5 config files');
+    my $p       = App::TimeTracker::Proto->new( home => $testdir );
+    my $c       = $p->load_config( dir( $testdir, (qw(a b c d)) ) );
+    is( $p->project,                         'd', 'project d' );
+    is( $c->{rt}{update_time_worked},        1,   'deep config' );
+    is( keys %{ $p->config_file_locations }, 5,   '5 config files' );
 }
 
 testlib::Fixtures::reset_tempdir();
 {
     explain('Test2');
     my $testdir = testlib::Fixtures::setup_tree('tree1');
-    my $p = App::TimeTracker::Proto->new(home=>$testdir);
-    my $c = $p->load_config(dir($testdir,(qw(a b))));
-    is($p->project,'b','project b');
-    is($c->{rt}{update_time_worked},undef,'not so deep config');
-    is(keys %{$p->config_file_locations},3, '3 config files');
+    my $p       = App::TimeTracker::Proto->new( home => $testdir );
+    my $c       = $p->load_config( dir( $testdir, (qw(a b)) ) );
+    is( $p->project,                         'b',   'project b' );
+    is( $c->{rt}{update_time_worked},        undef, 'not so deep config' );
+    is( keys %{ $p->config_file_locations }, 3,     '3 config files' );
 }
 
 testlib::Fixtures::reset_tempdir();
 {
     explain('Test3');
     my $testdir = testlib::Fixtures::setup_tree('tree1');
-    my $p = App::TimeTracker::Proto->new(home=>$testdir);
-    my $c = $p->load_config(dir($testdir,(qw(z))));
-    is($p->project,undef,'Project not defined');
-    is(keys %{$p->config_file_locations},1, '1 config files');
+    my $p       = App::TimeTracker::Proto->new( home => $testdir );
+    my $c       = $p->load_config( dir( $testdir, (qw(z)) ) );
+    is( $p->project,                         undef, 'Project not defined' );
+    is( keys %{ $p->config_file_locations }, 1,     '1 config files' );
 }
 
 testlib::Fixtures::reset_tempdir();
 {
     explain('Test4');
-    @ARGV=('--project','test');
+    @ARGV = ( '--project', 'test' );
     my $testdir = testlib::Fixtures::setup_tree('tree1');
-    my $p = App::TimeTracker::Proto->new(home=>$testdir);
-    my $c = $p->load_config(dir($testdir,(qw(z))));
-    is($p->project,'test','project via argv');
-    is(keys %{$p->config_file_locations},1, '1 config files');
+    my $p       = App::TimeTracker::Proto->new( home => $testdir );
+    my $c       = $p->load_config( dir( $testdir, (qw(z)) ) );
+    is( $p->project,                         'test', 'project via argv' );
+    is( keys %{ $p->config_file_locations }, 1,      '1 config files' );
 }
 
 done_testing();

--- a/t/Proto/run.t
+++ b/t/Proto/run.t
@@ -10,14 +10,14 @@ use App::TimeTracker::Proto;
 
 my $testdir = testlib::Fixtures::setup_tree('tree1');
 chdir($testdir);
-my $p = App::TimeTracker::Proto->new(home=>$testdir);
+my $p = App::TimeTracker::Proto->new( home => $testdir );
 
 trap {
     $p->run;
 };
 
-is ( $trap->exit, 0, 'exit()' );
-like($trap->stdout,qr/^Available commands:/,'List of commands');
-like($trap->stdout,qr/\tstart/,'start command in list');
+is( $trap->exit, 0, 'exit()' );
+like( $trap->stdout, qr/^Available commands:/, 'List of commands' );
+like( $trap->stdout, qr/\tstart/,              'start command in list' );
 
 done_testing();

--- a/t/Task/current.t
+++ b/t/Task/current.t
@@ -11,9 +11,9 @@ use App::TimeTracker::Data::Task;
 my $tmp = testlib::Fixtures->setup_running;
 
 foreach my $type (qw(current previous)) {
-    file_exists_ok($tmp->file($type));
+    file_exists_ok( $tmp->file($type) );
     my $task = App::TimeTracker::Data::Task->$type($tmp);
-    is($task->start->ymd,'2011-05-28','start date');
+    is( $task->start->ymd, '2011-05-28', 'start date' );
 }
 
 done_testing();

--- a/t/Task/helpers.t
+++ b/t/Task/helpers.t
@@ -8,31 +8,47 @@ use DateTime;
 
 use App::TimeTracker::Data::Task;
 
-{   # _calc_duration, rounded_minutes
-    my $task = App::TimeTracker::Data::Task->new({
-        project => 'test',
-        start   => DateTime->new(year=>2010,month=>2,day=>26,hour=>10,minute=>5,second=>42),
-        description=>'Some Test Task described in a very long sentence that will be probably be shortend',
-    });
-    my $stop = DateTime->new(year=>2010,month=>2,day=>26,hour=>12,minute=>25,second=>13);
+{    # _calc_duration, rounded_minutes
+    my $task = App::TimeTracker::Data::Task->new(
+        {   project => 'test',
+            start   => DateTime->new(
+                year   => 2010,
+                month  => 2,
+                day    => 26,
+                hour   => 10,
+                minute => 5,
+                second => 42
+            ),
+            description =>
+                'Some Test Task described in a very long sentence that will be probably be shortend',
+        }
+    );
+    my $stop = DateTime->new(
+        year   => 2010,
+        month  => 2,
+        day    => 26,
+        hour   => 12,
+        minute => 25,
+        second => 13
+    );
     $task->_calc_duration($stop);
-    is ($task->seconds,'8371','_calc_duration: seconds');
-    is ($task->duration,'02:19:31','_calc_duration: duration');
-    is ($task->rounded_minutes,140,'rounded_minutes');
+    is( $task->seconds,         '8371',     '_calc_duration: seconds' );
+    is( $task->duration,        '02:19:31', '_calc_duration: duration' );
+    is( $task->rounded_minutes, 140,        'rounded_minutes' );
 
-    $stop->add('hours'=>1);
+    $stop->add( 'hours' => 1 );
     $task->stop($stop);
     $task->_calc_duration;
-    is ($task->seconds,'11971','_calc_duration: seconds');
-    is ($task->duration,'03:19:31','_calc_duration: duration');
-    is ($task->rounded_minutes,200,'rounded_minutes');
-    is ($task->description_short,'Some Test Task described in a very long sentence...','description_short');
+    is( $task->seconds,         '11971',    '_calc_duration: seconds' );
+    is( $task->duration,        '03:19:31', '_calc_duration: duration' );
+    is( $task->rounded_minutes, 200,        'rounded_minutes' );
+    is( $task->description_short, 'Some Test Task described in a very long sentence...',
+        'description_short' );
 }
 
-{ # rounded_minutes
+{    # rounded_minutes
     my $task = App::TimeTracker::Data::Task->new(
-        {
-            project => 'test',
+        {   project => 'test',
             start   => DateTime->new(
                 year   => 2010,
                 month  => 2,

--- a/t/Task/start.t
+++ b/t/Task/start.t
@@ -10,23 +10,31 @@ use App::TimeTracker::Data::Task;
 local $ENV{TZ} = 'UTC';
 
 my $capture = IO::Capture::Stdout->new();
-my $tmp = testlib::Fixtures::setup_tempdir;
+my $tmp     = testlib::Fixtures::setup_tempdir;
 
 {
-    my $task = App::TimeTracker::Data::Task->new({
-        project => 'test',
-        start   => DateTime->new(year=>2010,month=>2,day=>26,hour=>10,minute=>5,second=>42),
-    });
+    my $task = App::TimeTracker::Data::Task->new(
+        {   project => 'test',
+            start   => DateTime->new(
+                year   => 2010,
+                month  => 2,
+                day    => 26,
+                hour   => 10,
+                minute => 5,
+                second => 42
+            ),
+        }
+    );
 
     $capture->start();
     $task->do_start($tmp);
     $capture->stop();
 
-    ok(-e $task->storage_location($tmp),'task is saved');
-    ok(-e $tmp.'/current','current is set');
+    ok( -e $task->storage_location($tmp), 'task is saved' );
+    ok( -e $tmp . '/current',             'current is set' );
 
     my $read = $capture->read;
-    like($read,qr/started working on test at 10:05:42/i,'stdout');
+    like( $read, qr/started working on test at 10:05:42/i, 'stdout' );
 }
 
 done_testing();

--- a/t/Task/storage_location.t
+++ b/t/Task/storage_location.t
@@ -11,13 +11,28 @@ use App::TimeTracker::Data::Task;
 my $tmp = testlib::Fixtures::setup_tempdir;
 
 {
-    my $task = App::TimeTracker::Data::Task->new({
-        project => 'test',
-        start   => DateTime->new(year=>2010,month=>2,day=>26,hour=>10,minute=>5,second=>42),
-    });
+    my $task = App::TimeTracker::Data::Task->new(
+        {   project => 'test',
+            start   => DateTime->new(
+                year   => 2010,
+                month  => 2,
+                day    => 26,
+                hour   => 10,
+                minute => 5,
+                second => 42
+            ),
+        }
+    );
 
-    cmp_bag ([$task->_filepath],[qw(2010 02 20100226-100542_test.trc)],'filepath has correct elements');
-    is($task->storage_location($tmp),$tmp->file('2010','02','20100226-100542_test.trc'),'storage_location');
+    cmp_bag(
+        [ $task->_filepath ],
+        [qw(2010 02 20100226-100542_test.trc)],
+        'filepath has correct elements'
+    );
+    is( $task->storage_location($tmp),
+        $tmp->file( '2010', '02', '20100226-100542_test.trc' ),
+        'storage_location'
+    );
 
 }
 

--- a/t/TimeTracker/datetime_coerce.t
+++ b/t/TimeTracker/datetime_coerce.t
@@ -12,9 +12,9 @@ package ThisTest;
 use Moose;
 extends 'App::TimeTracker';
 has 'dt' => (
-    isa=>'TT::DateTime',
-    is=>'ro',
-    coerce=>1,
+    isa    => 'TT::DateTime',
+    is     => 'ro',
+    coerce => 1,
 );
 
 package main;
@@ -23,19 +23,20 @@ local $ENV{TZ} = 'UTC';
 
 my $now = DateTime->now;
 $now->set_time_zone('local');
-my $date = DateTime->new(year=>2012,month=>2,day=>26,time_zone=>'UTC');
+my $date = DateTime->new( year => 2012, month => 2, day => 26, time_zone => 'UTC' );
 
 foreach my $test (
-    ['12:34',$now->clone->set(hour=>12,minute=>34,second=>0)],
-    ['0:1',$now->clone->set(hour=>0,minute=>1,second=>0)],
-    ['2012-02-26',$date->clone],
-    ['2012-02-26 12:34',$date->clone->set(hour=>12,minute=>34,second=>0)],
+    [ '12:34',            $now->clone->set( hour => 12, minute => 34, second => 0 ) ],
+    [ '0:1',              $now->clone->set( hour => 0,  minute => 1,  second => 0 ) ],
+    [ '2012-02-26',       $date->clone ],
+    [ '2012-02-26 12:34', $date->clone->set( hour => 12, minute => 34, second => 0 ) ],
+
     # for our crazy American friends...
-    ['26-02-2012',$date->clone],
-    ['26-02-2012 12:34',$date->clone->set(hour=>12,minute=>34,second=>0)],
+    [ '26-02-2012',       $date->clone ],
+    [ '26-02-2012 12:34', $date->clone->set( hour => 12, minute => 34, second => 0 ) ],
 ) {
-    my $tt = ThisTest->new(dt=>$test->[0],home=>$tmp, config=>{});
-    is($tt->dt->iso8601,$test->[1]->iso8601,join(' -> ',@$test));
+    my $tt = ThisTest->new( dt => $test->[0], home => $tmp, config => {} );
+    is( $tt->dt->iso8601, $test->[1]->iso8601, join( ' -> ', @$test ) );
 }
 
 done_testing();

--- a/t/TimeTracker/find_task_files.t
+++ b/t/TimeTracker/find_task_files.t
@@ -10,32 +10,32 @@ use App::TimeTracker;
 local $ENV{TZ} = 'UTC';
 
 my $tmp = testlib::Fixtures->setup_2011_05;
-my $t = App::TimeTracker->new(home=>$tmp,config=>{});
+my $t   = App::TimeTracker->new( home => $tmp, config => {} );
 
 {
-    my @files = $t->find_task_files({
-        from=>DateTime->new(year=>'2011',month=>5,day=>20),
-        to=>DateTime->new(year=>'2011',month=>5,day=>25),
-    });
-    is(scalar @files,6,'got 6 files');
-    is($files[0],$tmp->file('2011','05','20110520-093423_oe1_orf_at.trc'),'first file');
-    is($files[5],$tmp->file('2011','05','20110525-224324_App_TimeTracker.trc'),'last file');
+    my @files = $t->find_task_files(
+        {   from => DateTime->new( year => '2011', month => 5, day => 20 ),
+            to   => DateTime->new( year => '2011', month => 5, day => 25 ),
+        }
+    );
+    is( scalar @files, 6, 'got 6 files' );
+    is( $files[0],     $tmp->file( '2011', '05', '20110520-093423_oe1_orf_at.trc' ), 'first file' );
+    is( $files[5], $tmp->file( '2011', '05', '20110525-224324_App_TimeTracker.trc' ), 'last file' );
 }
 
 {
-    my @files = $t->find_task_files({
-        projects=>['TimeTracker'],
-    });
-    is(scalar @files,7,'got 7 files');
-    is((scalar grep { /App_TimeTracker/ } @files),7,'all match project');
+    my @files = $t->find_task_files( { projects => ['TimeTracker'], } );
+    is( scalar @files,                              7, 'got 7 files' );
+    is( ( scalar grep {/App_TimeTracker/} @files ), 7, 'all match project' );
 }
 
 {
-    my @files = $t->find_task_files({
-        from=>DateTime->new(year=>'2011',month=>5,day=>1),
-        projects=>['oe1'],
-    });
-    is(scalar @files,16,'got 16 files');
+    my @files = $t->find_task_files(
+        {   from     => DateTime->new( year => '2011', month => 5, day => 1 ),
+            projects => ['oe1'],
+        }
+    );
+    is( scalar @files, 16, 'got 16 files' );
 }
 
 done_testing();

--- a/t/TimeTracker/helpers.t
+++ b/t/TimeTracker/helpers.t
@@ -10,44 +10,45 @@ use App::TimeTracker;
 my $tmp = testlib::Fixtures::setup_tempdir;
 local $ENV{TZ} = 'UTC';
 
-my %BASE = ( home=>$tmp, config=>{} );
+my %BASE = ( home => $tmp, config => {} );
 
-{ # $self->now
-    my $exp = DateTime->now(time_zone=>'local');
+{    # $self->now
+    my $exp = DateTime->now( time_zone => 'local' );
     my $got = App::TimeTracker->now;
-    is($exp->ymd,$got->ymd,'$self->now: ymd');
-    is($exp->strftime('%H:%M'),$got->strftime('%H:%M'),'$self->now: hh:mm');
+    is( $exp->ymd,               $got->ymd,               '$self->now: ymd' );
+    is( $exp->strftime('%H:%M'), $got->strftime('%H:%M'), '$self->now: hh:mm' );
 }
 
-{ # beautify_seconds
+{    # beautify_seconds
     my @tests = (
-        [undef, '0'],
-        ['0', '0'],
-        ['59', '00:00:59'],
-        ['60', '00:01:00'],
-        ['61', '00:01:01'],
-        ['263', '00:04:23'],
-        [3*60*60, '03:00:00'],
-        [(4*60*60)+(42*60)+21, '04:42:21'],
-        [(18*60*60), '18:00:00'],
-        [(111*60*60)+11, '111:00:11'],
+        [ undef,                              '0' ],
+        [ '0',                                '0' ],
+        [ '59',                               '00:00:59' ],
+        [ '60',                               '00:01:00' ],
+        [ '61',                               '00:01:01' ],
+        [ '263',                              '00:04:23' ],
+        [ 3 * 60 * 60,                        '03:00:00' ],
+        [ ( 4 * 60 * 60 ) + ( 42 * 60 ) + 21, '04:42:21' ],
+        [ ( 18 * 60 * 60 ),                   '18:00:00' ],
+        [ ( 111 * 60 * 60 ) + 11,             '111:00:11' ],
     );
     foreach (@tests) {
-        is(App::TimeTracker->beautify_seconds($_->[0]),$_->[1],join(' -> ',map { $_ // 'UNDEF'} @$_));
+        is( App::TimeTracker->beautify_seconds( $_->[0] ),
+            $_->[1], join( ' -> ', map { $_ // 'UNDEF' } @$_ ) );
     }
 }
 
-{ # tags
-    my $t = App::TimeTracker->new(\%BASE);
-    cmp_bag($t->tags,[],'no tags');
+{    # tags
+    my $t = App::TimeTracker->new( \%BASE );
+    cmp_bag( $t->tags, [], 'no tags' );
     $t->add_tag('1');
     $t->add_tag('2');
     $t->insert_tag('3');
-    cmp_deeply($t->tags,[3,1,2],'some tags');
+    cmp_deeply( $t->tags, [ 3, 1, 2 ], 'some tags' );
 
 }
 
-{ # to / from
+{    # to / from
     my $class = Moose::Meta::Class->create_anon_class(
         superclasses => ['App::TimeTracker'],
         roles        => ['App::TimeTracker::Command::Core'],
@@ -56,45 +57,34 @@ my %BASE = ( home=>$tmp, config=>{} );
     $class_name->_load_attribs_worked($class);
 
     no warnings 'redefine';
-    local *DateTime::now = sub { return DateTime->new( year => 2011, month => 9, day => 7, hour => 12 ) };
+    local *DateTime::now =
+        sub { return DateTime->new( year => 2011, month => 9, day => 7, hour => 12 ) };
     {
-        my $t1 = $class_name->new({
-            %BASE,
-            this    => 'week',
-        });
+        my $t1 = $class_name->new( { %BASE, this => 'week', } );
 
-        is($t1->from->iso8601,'2011-09-05T00:00:00','From 1 ok');
-        is($t1->to->iso8601,'2011-09-11T23:59:59','To 1 ok');
+        is( $t1->from->iso8601, '2011-09-05T00:00:00', 'From 1 ok' );
+        is( $t1->to->iso8601,   '2011-09-11T23:59:59', 'To 1 ok' );
     }
 
     {
-        my $t2 = $class_name->new({
-            %BASE,
-            last    => 'week',
-        });
+        my $t2 = $class_name->new( { %BASE, last => 'week', } );
 
-        is($t2->from->iso8601,'2011-08-29T00:00:00','From 2 ok');
-        is($t2->to->iso8601,'2011-09-04T23:59:59','To 2 ok');
+        is( $t2->from->iso8601, '2011-08-29T00:00:00', 'From 2 ok' );
+        is( $t2->to->iso8601,   '2011-09-04T23:59:59', 'To 2 ok' );
     }
 
     {
-        my $t3 = $class_name->new({
-            %BASE,
-            last    => 'month',
-        });
+        my $t3 = $class_name->new( { %BASE, last => 'month', } );
 
-        is($t3->from->iso8601,'2011-08-01T00:00:00','From 3 ok');
-        is($t3->to->iso8601,'2011-08-31T23:59:59','To 3 ok');
+        is( $t3->from->iso8601, '2011-08-01T00:00:00', 'From 3 ok' );
+        is( $t3->to->iso8601,   '2011-08-31T23:59:59', 'To 3 ok' );
     }
 
     {
-        my $t4 = $class_name->new({
-            %BASE,
-            last    => 'day',
-        });
+        my $t4 = $class_name->new( { %BASE, last => 'day', } );
 
-        is($t4->from->iso8601,'2011-09-06T00:00:00','From 4 ok');
-        is($t4->to->iso8601,'2011-09-06T23:59:59','To 4 ok');
+        is( $t4->from->iso8601, '2011-09-06T00:00:00', 'From 4 ok' );
+        is( $t4->to->iso8601,   '2011-09-06T23:59:59', 'To 4 ok' );
     }
 }
 


### PR DESCRIPTION
This patch adds a usable `perltidy` configuration and then uses this configuration to "tidy" the test files.