### PR TITLE
Output projects.json using canonical setting

### DIFF
--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -482,7 +482,7 @@ sub cmd_init {
 EOCONFIG
 
     my $projects_file = $self->home->file('projects.json');
-    my $coder         = JSON::XS->new->utf8->pretty->relaxed;
+    my $coder         = JSON::XS->new->utf8->pretty->canonical->relaxed;
     if ( -e $projects_file ) {
         my $projects = $coder->decode( scalar $projects_file->slurp );
         $projects->{$project} =

--- a/lib/App/TimeTracker/Proto.pm
+++ b/lib/App/TimeTracker/Proto.pm
@@ -82,7 +82,7 @@ has 'json_decoder' => ( is => 'ro', isa => 'JSON::XS', lazy_build => 1 );
 
 sub _build_json_decoder {
     my $self = shift;
-    return JSON::XS->new->utf8->pretty->relaxed;
+    return JSON::XS->new->utf8->pretty->canonical->relaxed;
 }
 
 sub run {


### PR DESCRIPTION
So that it retains the same order between runs of `tracker`. This is
useful if the TimeTracker home directory is kept under VCS.
