### PR TITLE
Set project name on init + Use project name from config file if possible

### DIFF
--- a/lib/App/TimeTracker/Command/Core.pm
+++ b/lib/App/TimeTracker/Command/Core.pm
@@ -472,8 +472,13 @@ sub cmd_init {
         exit;
     }
 
-    my @dirs    = $cwd->dir_list;
-    my $project = $dirs[-1];
+    my $project;
+    if( $self->has_current_project ) {
+        $project = $self->_current_project;
+    } else {
+        my @dirs    = $cwd->dir_list;
+        $project = $dirs[-1];
+    }
     my $fh      = $cwd->file('.tracker.json')->openw;
     say $fh <<EOCONFIG;
 {
@@ -700,6 +705,18 @@ sub _load_attribs_recalc_trackfile {
             isa      => 'Str',
             is       => 'ro',
             required => 1,
+        }
+    );
+}
+
+sub _load_attribs_init {
+    my ( $class, $meta ) = @_;
+    $meta->add_attribute(
+        'project' => {
+            isa           => 'Str',
+            is            => 'ro',
+            documentation => 'Project name to initialize',
+            lazy_build    => 1,
         }
     );
 }

--- a/lib/App/TimeTracker/Proto.pm
+++ b/lib/App/TimeTracker/Proto.pm
@@ -191,7 +191,7 @@ WALKUP: while ( $try++ < 30 ) {
             $config = merge( $config, $this_config );
 
             my @path    = $config_file->parent->dir_list;
-            my $project = $path[-1];
+            my $project = exists $this_config->{project} ? $this_config->{project} : $path[-1];
             $cfl->{$project} = $config_file->stringify;
             $self->project($project)
                 unless $self->has_project;


### PR DESCRIPTION
- Add flag to `init` command to set project name.
- Set the project attribute from config file if possible (rather than just the
  last component of the path).

This is connected to <https://github.com/domm/App-TimeTracker/issues/57>.
